### PR TITLE
feature: Chain swap mainnet

### DIFF
--- a/src/Vault.vue
+++ b/src/Vault.vue
@@ -82,13 +82,9 @@ div(v-else-if=("isDrizzleInitialized && wrong_chain"))
   div(class="notFound")
     p ❌⛓
     p Wrong Chain
-    p.smallish(
-      v-if="this.config.CHAIN_ID === 1"
-    ) Change it on Metamask
     div
       button.unstyled(
-        @click.prevent="on_switch_chain"
-        v-if="this.config.CHAIN_ID !== 1",
+        @click.prevent="on_switch_chain",
       ) 🔀 Switch it on Metamask
     a.smallish(href="/") Back Home
 div(v-else)
@@ -292,15 +288,23 @@ export default {
         console.error(`window.ethereum not initialized`)
         return
       }
-      if (!chains[this.config.CHAIN_ID] || !chains[this.config.CHAIN_ID].chain_swap) {
+      if (!chains[this.config.CHAIN_ID]) {
         console.error(`invalid chain_swap configuration`)
         return
       }
-      window.ethereum.request({
-        method: 'wallet_addEthereumChain',
-        params: [chains[this.config.CHAIN_ID].chain_swap, this.activeAccount],
-      })
-      .catch((error) => console.error(error));
+      if (this.config.CHAIN_ID === 1) {
+        window.ethereum.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{chainId: '0x1'}],
+        })
+        .catch((error) => console.error(error));
+      } else {
+        window.ethereum.request({
+          method: 'wallet_addEthereumChain',
+          params: [chains[this.config.CHAIN_ID].chain_swap, this.activeAccount],
+        })
+        .catch((error) => console.error(error));
+      }
     }
   },
   computed: {


### PR DESCRIPTION
## What it does ✨
Extending the #66 PR, adding the `wallet_switchEthereumChain` method from the [EIP 3326](https://github.com/rekmarks/EIPs/blob/3326-create/EIPS/eip-3326.md) in order to switch from any chain to mainnet

## How to test ✅
The project should be able to start with a `yarn && yarn run serve`.
If you try to access a vault which is not on your current network, a button with `🔀 Switch it on Metamask` should be available and should add then switch to the corresponding network, even on the mainnet.

## Resources ✏️
- [ChainList](https://chainlist.org/)
- [EIP 3326](https://github.com/rekmarks/EIPs/blob/3326-create/EIPS/eip-3326.md)

## More 🦖
More element, but not directly related to this. I am available to work on that if needed, just tell me !

- It could be nice to remove the network switcher from the vaultPage, to avoid dead-end if the users switch to the wrong network.
- It could be nice to add a "back Home" button from the vault page to get back to the vault list.