### PR TITLE
Hoftix/DepositLimit fix for new vaults

### DIFF
--- a/src/Vault.vue
+++ b/src/Vault.vue
@@ -312,7 +312,7 @@ export default {
       return this.call("Vault", "totalAssets", []);
     },
     vault_available_limit() {
-      if (this.config.VAULT_STATUS == 'active' || this.config.VAULT_STATUS == 'stealth' || this.config.VAULT_STATUS == '') {
+      if (this.config.VAULT_STATUS !== 'withdraw') {
         return this.call("Vault", "availableDepositLimit", []);
       } else {
         return BN_ZERO;


### PR DESCRIPTION
## What it does ✨
Following the report on Telegram about an issue on the new vault, I made some change to set the deposit limit to 0 for `withdraw` vaults only, instead of an explicit allowance (aka, 'active' + 'stealth' + 'new' + '')

## How to test ✅
Not much change, the deposit limit should be available for all the vaults except the ones set to withdraw