### PR TITLE
Feature/API custom rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ https://ape.tax/api/vaults
 ```
 
 The following options are available:
-- `?network=1` for Mainnet (default)
-- `?network=56` for BSC
-- `?network=137` for Polygon
-- `?network=250` for Fantom Opera
+- *network*
+	- `?network=1` for Mainnet (default)
+	- `?network=56` for BSC
+	- `?network=137` for Polygon
+	- `?network=250` for Fantom Opera
+- *rpc*
+	- `?rpc=YOU_CUSTOM_RPC` to use a specific RPC for this request
+
 
 The returned data is cached for 10 minutes.
 This route returns a JSON object with the following structure:

--- a/pages/api/vaults.js
+++ b/pages/api/vaults.js
@@ -44,9 +44,13 @@ async function newEthCallProvider(provider) {
 	return ethcallProvider;
 }
 
-export default fn(async ({network = 1}) => {
+export default fn(async ({network = 1, rpc}) => {
 	network = Number(network);
-	const	ethcallProvider = await newEthCallProvider(getProvider(network));
+	let		provider = getProvider(network);
+	if (rpc !== undefined) {
+		provider = new ethers.providers.JsonRpcProvider(rpc);
+	}
+	const	ethcallProvider = await newEthCallProvider(provider);
 	const	_vaults = [];
 	const	_calls = [];
 


### PR DESCRIPTION
## What it does ✨
Add support for custom RPC on the API request.
Users can use `?rpc=https://bsc-dataseed.binance.org` for example to use a custom RPC to fetch the data from the blockchain. Can be used for various reason (key limitation first)
Better option for #105

## How to test ✅
Try to perform a request with you custom RPC to see if you could get data !
