### PR TITLE
Feature/ftm Vaults Status

### DIFF
--- a/utils/vaults.json
+++ b/utils/vaults.json
@@ -1,10 +1,3 @@
-/*
- * @Author:				The Ape Community
- * @Twitter:				@ape_tax
- * @Date:					Wednesday October 20th 2021
- * @Filename:				vaults.json
- */
-
 {
   "yusdcidle": {
     "TITLE": "USDc Idle",
@@ -483,7 +476,7 @@
     "WANT_ADDR": "0x841fad6eae12c286d1fd18d1d525dffa75c7effe",
     "WANT_SYMBOL": "BOO",
     "COINGECKO_SYMBOL": "spookyswap",
-    "VAULT_STATUS": "active",
+    "VAULT_STATUS": "withdraw",
     "CHAIN_ID": 250
   },
   "rai": {


### PR DESCRIPTION
## Description
Set some FTM vaults as `endorsed` and one as `withdraw`

## Type of change
- [X] Vault Status

## Change details
- Set [Spooky Skeletons](ape.tax/spooky) as `withdraw` (no strategies)
- Set [The Fantom](ape.tax/the-fantom) as `endorsed`
- Set [The Fantom](ape.tax/the-fantom) as `endorsed`
- Set [Fantom's Dai Hard](ape.tax/fantom-dai) as `endorsed`
- Set [Ghost YFI](ape.tax/ghost-yfi) as `endorsed`
- Set [Mr. MIMe](ape.tax/ftm_mr_mime) as `endorsed`
- Set [Ghosty Eagle](ape.tax/ftm_usdc) as `endorsed`

## Resources
*NA*